### PR TITLE
CHEMH-171 | @jdwjdwjdw | Fixup search form HTML a11y issues

### DIFF
--- a/templates/form--search.html.twig
+++ b/templates/form--search.html.twig
@@ -1,13 +1,7 @@
-{% set attributes = attributes.addClass('su-site-search search-results search-results-page') %}
-
-{% include "@basic-dist/decanter/components/site-search/site-search.twig" with
-  {
-    "attributes": attributes|without('class', 'role'),
-    "modifier_class": attributes.class,
-    "action": elements.content['#action'],
-    "method": "get",
-    "search_label": "Search this site"|t,
-    "placeholder": "Search ..."|t,
-    "search_input_name": "key",
-  }
-%}
+<div class="su-site-search search-results search-results-page" role="search">
+ <form {{ attributes }}>
+  <label class="su-site-search__sr-label" for="search-results-key">Search ...</label>
+  <input type="text" id="search-results-key" name="search-results-key" class="su-site-search__input" placeholder="Search ..." maxlength="128">
+  <button type="submit" name="search" class="su-site-search__submit su-sr-only-text">Submit Search</button>
+ </form>
+</div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- [CHEMH-171](https://stanfordits.atlassian.net/browse/CHEMH-171): A11y|Search: Multiple HTML errors.
- Fixup the HTML errors related to the search form on the search-results page identified in [CHEMH-171](https://stanfordits.atlassian.net/browse/CHEMH-171)

# Review By (Date)
- When convenient

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Navigate to the search results page at `/search?key=Research&search=`
3. Test that page at https://validator.w3.org/nu/ and using the ARC Toolkit chrome extension, and confirm that the errors are no longer listed
4. Review code 🍎 

# Associated Issues and/or People
- [CHEMH-171](https://stanfordits.atlassian.net/browse/CHEMH-171): A11y|Search: Multiple HTML errors.


[CHEMH-171]: https://stanfordits.atlassian.net/browse/CHEMH-171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CHEMH-171]: https://stanfordits.atlassian.net/browse/CHEMH-171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CHEMH-171]: https://stanfordits.atlassian.net/browse/CHEMH-171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ