### PR TITLE
CHEMH-241 | @jdwjdwjdw | Fixup search results page input name

### DIFF
--- a/templates/form--search.html.twig
+++ b/templates/form--search.html.twig
@@ -1,7 +1,7 @@
 <div class="su-site-search search-results search-results-page" role="search">
  <form {{ attributes }}>
   <label class="su-site-search__sr-label" for="search-results-key">Search ...</label>
-  <input type="text" id="search-results-key" name="search-results-key" class="su-site-search__input" placeholder="Search ..." maxlength="128">
+  <input type="text" id="search-results-key" name="key" class="su-site-search__input" placeholder="Search ..." maxlength="128">
   <button type="submit" name="search" class="su-site-search__submit su-sr-only-text">Submit Search</button>
  </form>
 </div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- [CHEMH-241](https://stanfordits.atlassian.net/browse/CHEMH-241): BUG | Search page search field does not work
- Fixup search input name to remove incorrect search URL created if you search on the search-results page at chemh.stanford.edu (see https://chemh.stanford.edu/search?search-results-key=medicine&search=)

# Review By (Date)
- ASAP

# Criticality
- High

# Urgency
- High

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Navigate to search page at `/search`
3. Type a search into the search input and press enter
4. Confirm that the search URL is correct, and results are being displayed.
5. Review code 🦕 

# Associated Issues and/or People
- [CHEMH-241](https://stanfordits.atlassian.net/browse/CHEMH-241): BUG | Search page search field does not work

[CHEMH-241]: https://stanfordits.atlassian.net/browse/CHEMH-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CHEMH-241]: https://stanfordits.atlassian.net/browse/CHEMH-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ